### PR TITLE
feat: can override spot instance type to be one-time

### DIFF
--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -159,7 +159,7 @@ func buildOptionGroups() []OptionGroup {
 				"AWS_AMI", "AWS_DISK_SIZE", "AWS_ROOT_DEVICE", "AWS_INSTANCE_TYPE",
 				"AWS_VPC_ID", "AWS_SUBNET_ID", "AWS_SECURITY_GROUP_ID", "AWS_INSTANCE_PROFILE_ARN",
 				"AWS_INSTANCE_TAGS", "AWS_USE_INSTANCE_CONNECT_ENDPOINT", "AWS_INSTANCE_CONNECT_ENDPOINT_ID",
-				"AWS_USE_SPOT_INSTANCE", "AWS_USE_SESSION_MANAGER", "AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER",
+				"AWS_USE_SPOT_INSTANCE", "AWS_SPOT_INSTANCE_TYPE", "AWS_USE_SESSION_MANAGER", "AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER",
 				"AWS_USE_ROUTE53", "AWS_ROUTE53_ZONE_NAME", "AWS_AVAILABILITY_ZONE", "AWS_USE_NESTED_VIRTUALIZATION",
 			},
 		},
@@ -286,6 +286,11 @@ func buildOptions() Options {
 			Description: "Prefer the Spot instead of On-Demand instances.",
 			Type:        "boolean",
 			Default:     "false",
+		},
+		"AWS_SPOT_INSTANCE_TYPE": {
+			Description: "The spot instance request type. Use 'persistent' to keep the request active after interruption, or 'one-time' for a single fulfillment attempt. Only used when AWS_USE_SPOT_INSTANCE is true.",
+			Default:     "persistent",
+			Suggestions: []string{"persistent", "one-time"},
 		},
 		"AWS_USE_SESSION_MANAGER": {
 			Description: "If defined, will try to connect to the ec2 instance via the AWS Session Manager",

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -988,13 +988,16 @@ func Create(
 		}
 	}
 	if providerAws.Config.UseSpotInstance {
-		providerAws.Log.Debugf("using spot instance")
+		providerAws.Log.Debugf("using spot instance (type: %s)", providerAws.Config.SpotInstanceType)
+		spotOpts := &types.SpotMarketOptions{
+			SpotInstanceType: types.SpotInstanceType(providerAws.Config.SpotInstanceType),
+		}
+		if providerAws.Config.SpotInstanceType == "persistent" {
+			spotOpts.InstanceInterruptionBehavior = "stop"
+		}
 		instance.InstanceMarketOptions = &types.InstanceMarketOptionsRequest{
-			MarketType: "spot",
-			SpotOptions: &types.SpotMarketOptions{
-				SpotInstanceType:             "persistent",
-				InstanceInterruptionBehavior: "stop",
-			},
+			MarketType:  "spot",
+			SpotOptions: spotOpts,
 		}
 	}
 

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -23,6 +23,7 @@ var (
 	AWS_USE_INSTANCE_CONNECT_ENDPOINT   = "AWS_USE_INSTANCE_CONNECT_ENDPOINT"
 	AWS_INSTANCE_CONNECT_ENDPOINT_ID    = "AWS_INSTANCE_CONNECT_ENDPOINT_ID"
 	AWS_USE_SPOT_INSTANCE               = "AWS_USE_SPOT_INSTANCE"
+	AWS_SPOT_INSTANCE_TYPE              = "AWS_SPOT_INSTANCE_TYPE"
 	AWS_USE_SESSION_MANAGER             = "AWS_USE_SESSION_MANAGER"
 	AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER = "AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER"
 	AWS_USE_ROUTE53                     = "AWS_USE_ROUTE53"
@@ -51,6 +52,7 @@ type Options struct {
 	UseInstanceConnectEndpoint bool
 	InstanceConnectEndpointID  string
 	UseSpotInstance            bool
+	SpotInstanceType           string
 	UseSessionManager          bool
 	KmsKeyARNForSessionManager string
 	UseRoute53Hostnames        bool
@@ -96,6 +98,10 @@ func FromEnv(init, withFolder bool) (*Options, error) {
 	retOptions.UseInstanceConnectEndpoint = os.Getenv(AWS_USE_INSTANCE_CONNECT_ENDPOINT) == strTrue
 	retOptions.InstanceConnectEndpointID = os.Getenv(AWS_INSTANCE_CONNECT_ENDPOINT_ID)
 	retOptions.UseSpotInstance = os.Getenv(AWS_USE_SPOT_INSTANCE) == strTrue
+	retOptions.SpotInstanceType = os.Getenv(AWS_SPOT_INSTANCE_TYPE)
+	if retOptions.SpotInstanceType == "" {
+		retOptions.SpotInstanceType = "persistent"
+	}
 	retOptions.UseSessionManager = os.Getenv(AWS_USE_SESSION_MANAGER) == strTrue
 	retOptions.KmsKeyARNForSessionManager = os.Getenv(AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER)
 	retOptions.UseRoute53Hostnames = os.Getenv(AWS_USE_ROUTE53) == strTrue


### PR DESCRIPTION
## Add configurable spot instance type (`AWS_SPOT_INSTANCE_TYPE`)

### Problem

The spot instance request type is hardcoded to `persistent` with `InstanceInterruptionBehavior: stop`. This creates a new spot instance with no devpod agent running if the original spot instance is terminated. Besides, the volume of the original spot instance would be lost with the instance terminated. There is not much advantages replacing with a new spot instance.

Fixes #75 

### Solution

Introduce a new provider option `AWS_SPOT_INSTANCE_TYPE` that accepts `persistent` (default) or `one-time`.

- **`persistent`** — keeps the spot request active after interruption; interrupted instances are stopped (existing behavior, now explicit).
- **`one-time`** — single fulfillment attempt; interrupted instances are terminated (AWS default for one-time).

### Usage

devpod provider set-options aws AWS_SPOT_INSTANCE_TYPE=one-time

#### Test result
```
% aws ec2 describe-spot-instance-requests  --spot-instance-request-ids sir-mvxqc8ng | jq '.SpotInstanceRequests[] | "\(.Type) \(.InstanceInterruptionBehavior)"'
"one-time terminate"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS_SPOT_INSTANCE_TYPE configuration option to specify AWS Spot instance types ("persistent" or "one-time"), with "persistent" as the default setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->