### PR TITLE
fix: check for existing groups in correct file

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1471,9 +1471,9 @@ func GetInjectKeypairScript(config *options.Options) (string, error) {
 	resultScript := `#!/bin/sh
 useradd devpod -d /home/devpod
 mkdir -p /home/devpod
-if grep -q sudo /etc/groups; then
+if grep -q sudo /etc/group; then
 	usermod -aG sudo devpod
-elif grep -q wheel /etc/groups; then
+elif grep -q wheel /etc/group; then
 	usermod -aG wheel devpod
 fi
 echo "devpod ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/91-devpod


### PR DESCRIPTION
The file that lists which users belong to which groups is /etc/group,
not /etc/groups. The incorrect path would have prevented the devpod
user from being added to the sudo and wheel groups as intended.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected EC2 instance user-data group checks to reference the proper system group file, ensuring the created user is detected for elevated group assignment.
  * No other behavioral changes to the user creation flow beyond fixing the file path used for group detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->