### PR TITLE
fix: three critical fixes for data volume snapshot boot on Nitro instances

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1064,7 +1064,7 @@ func Create(
 	instance, r53Zone, err := buildRunInstancesInput(ctx, providerAws, subnet)
 	if err != nil {
 		if dataVolumeID != "" {
-			deleteVolume(cfg, dataVolumeID)
+			deleteVolume(cfg, dataVolumeID, providerAws.Log)
 		}
 		return Machine{}, err
 	}
@@ -1075,7 +1075,7 @@ func Create(
 	result, err := svc.RunInstances(ctx, instance)
 	if err != nil {
 		if dataVolumeID != "" {
-			deleteVolume(cfg, dataVolumeID)
+			deleteVolume(cfg, dataVolumeID, providerAws.Log)
 		}
 		return Machine{}, err
 	}
@@ -1089,12 +1089,12 @@ func Create(
 			InstanceIds: []string{instanceID},
 		}, 5*time.Minute); err != nil {
 			terminateOnCleanup(providerAws, instanceID)
-			deleteVolume(cfg, dataVolumeID)
+			deleteVolume(cfg, dataVolumeID, providerAws.Log)
 			return Machine{}, fmt.Errorf("wait for instance %s to be running: %w", instanceID, err)
 		}
 		if err := attachDataVolume(ctx, providerAws, instanceID, dataVolumeID); err != nil {
 			terminateOnCleanup(providerAws, instanceID)
-			deleteVolume(cfg, dataVolumeID)
+			deleteVolume(cfg, dataVolumeID, providerAws.Log)
 			return Machine{}, err
 		}
 	}
@@ -1111,7 +1111,7 @@ func Create(
 		if err != nil {
 			terminateOnCleanup(providerAws, instanceID)
 			if dataVolumeID != "" {
-				deleteVolume(cfg, dataVolumeID)
+				deleteVolume(cfg, dataVolumeID, providerAws.Log)
 			}
 			return Machine{}, fmt.Errorf("create Route53 record: %w", err)
 		}
@@ -1334,19 +1334,23 @@ func attachDataVolume(
 // cleanup succeeds even when the caller's context is cancelled. If the volume
 // is still in-use (e.g. instance is terminating), it waits for it to become
 // available before deleting.
-func deleteVolume(awsCfg aws.Config, volumeID string) {
+func deleteVolume(awsCfg aws.Config, volumeID string, logs log.Logger) {
 	cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 	svc := ec2.NewFromConfig(awsCfg)
 
 	waiter := ec2.NewVolumeAvailableWaiter(svc)
-	_ = waiter.Wait(cleanupCtx, &ec2.DescribeVolumesInput{
+	if err := waiter.Wait(cleanupCtx, &ec2.DescribeVolumesInput{
 		VolumeIds: []string{volumeID},
-	}, 5*time.Minute)
+	}, 5*time.Minute); err != nil {
+		logs.Warnf("failed to wait for volume %s to become available: %v", volumeID, err)
+	}
 
-	_, _ = svc.DeleteVolume(cleanupCtx, &ec2.DeleteVolumeInput{
+	if _, err := svc.DeleteVolume(cleanupCtx, &ec2.DeleteVolumeInput{
 		VolumeId: aws.String(volumeID),
-	})
+	}); err != nil {
+		logs.Warnf("failed to delete volume %s: %v", volumeID, err)
+	}
 }
 
 func applyInstanceProfile(

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1695,17 +1695,17 @@ if ! mountpoint -q "%[2]s"; then
 fi
 case "$DATA_FSTYPE" in ext4) resize2fs "$DATA_DEV" 2>/dev/null;; xfs) xfs_growfs "%[2]s" 2>/dev/null;; esac
 chown devpod:devpod "%[2]s"
-mkdir -p "%[2]s/.containerd-root"
-mkdir -p /var/lib/containerd
+mkdir -p "%[2]s/.containerd-root" || { echo "ERROR: failed to create containerd root dir" >&2; exit 1; }
+mkdir -p /var/lib/containerd || { echo "ERROR: failed to create /var/lib/containerd" >&2; exit 1; }
 if ! mountpoint -q /var/lib/containerd; then
-  mount --bind "%[2]s/.containerd-root" /var/lib/containerd
+  mount --bind "%[2]s/.containerd-root" /var/lib/containerd || { echo "ERROR: failed to bind-mount containerd root" >&2; exit 1; }
 fi
-if ! grep -q '%[2]s/.containerd-root /var/lib/containerd' /etc/fstab; then
-  echo "%[2]s/.containerd-root /var/lib/containerd none bind 0 0" >> /etc/fstab
+if ! grep -qF '%[2]s/.containerd-root /var/lib/containerd' /etc/fstab; then
+  echo "%[2]s/.containerd-root /var/lib/containerd none bind 0 0" >> /etc/fstab || { echo "ERROR: failed to update /etc/fstab" >&2; exit 1; }
 fi
 if [ -n "$SNAPSHOT_ID" ] && [ -d "%[2]s/containers" ]; then
-  rm -rf "%[2]s/containers"/*
-  rm -rf "%[2]s/network/files"/*
+  rm -rf "%[2]s/containers"/* || true
+  rm -rf "%[2]s/network/files"/* || true
 fi`
 }
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1084,6 +1084,15 @@ func Create(
 	instanceID := aws.ToString(result.Instances[0].InstanceId)
 
 	if dataVolumeID != "" {
+		svc := ec2.NewFromConfig(providerAws.AwsConfig)
+		waiter := ec2.NewInstanceRunningWaiter(svc)
+		if err := waiter.Wait(ctx, &ec2.DescribeInstancesInput{
+			InstanceIds: []string{instanceID},
+		}, 5*time.Minute); err != nil {
+			terminateOnCleanup(providerAws, instanceID)
+			deleteVolume(cfg, dataVolumeID)
+			return Machine{}, fmt.Errorf("wait for instance %s to be running: %w", instanceID, err)
+		}
 		if err := attachDataVolume(ctx, providerAws, instanceID, dataVolumeID); err != nil {
 			terminateOnCleanup(providerAws, instanceID)
 			deleteVolume(cfg, dataVolumeID)
@@ -1682,7 +1691,19 @@ if ! mountpoint -q "%[2]s"; then
   echo "ERROR: failed to mount data volume at %[2]s" >&2; exit 1
 fi
 case "$DATA_FSTYPE" in ext4) resize2fs "$DATA_DEV" 2>/dev/null;; xfs) xfs_growfs "%[2]s" 2>/dev/null;; esac
-chown devpod:devpod "%[2]s"`
+chown devpod:devpod "%[2]s"
+mkdir -p "%[2]s/.containerd-root"
+mkdir -p /var/lib/containerd
+if ! mountpoint -q /var/lib/containerd; then
+  mount --bind "%[2]s/.containerd-root" /var/lib/containerd
+fi
+if ! grep -q '%[2]s/.containerd-root /var/lib/containerd' /etc/fstab; then
+  echo "%[2]s/.containerd-root /var/lib/containerd none bind 0 0" >> /etc/fstab
+fi
+if [ -n "$SNAPSHOT_ID" ] && [ -d "%[2]s/containers" ]; then
+  rm -rf "%[2]s/containers"/*
+  rm -rf "%[2]s/network/files"/*
+fi`
 }
 
 func logCallerIdentity(ctx context.Context, cfg aws.Config, logs log.Logger) error {

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1698,10 +1698,13 @@ chown devpod:devpod "%[2]s"
 mkdir -p "%[2]s/.containerd-root" || { echo "ERROR: failed to create containerd root dir" >&2; exit 1; }
 mkdir -p /var/lib/containerd || { echo "ERROR: failed to create /var/lib/containerd" >&2; exit 1; }
 if ! mountpoint -q /var/lib/containerd; then
-  mount --bind "%[2]s/.containerd-root" /var/lib/containerd || { echo "ERROR: failed to bind-mount containerd root" >&2; exit 1; }
+  if ! mount --bind "%[2]s/.containerd-root" /var/lib/containerd; then
+    echo "ERROR: failed to bind-mount containerd root" >&2; exit 1
+  fi
 fi
 if ! grep -qF '%[2]s/.containerd-root /var/lib/containerd' /etc/fstab; then
-  echo "%[2]s/.containerd-root /var/lib/containerd none bind 0 0" >> /etc/fstab || { echo "ERROR: failed to update /etc/fstab" >&2; exit 1; }
+  FSTAB_ENTRY="%[2]s/.containerd-root /var/lib/containerd none bind 0 0"
+  echo "$FSTAB_ENTRY" >> /etc/fstab || { echo "ERROR: failed to update /etc/fstab" >&2; exit 1; }
 fi
 if [ -n "$SNAPSHOT_ID" ] && [ -d "%[2]s/containers" ]; then
   rm -rf "%[2]s/containers"/* || true

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1084,7 +1084,6 @@ func Create(
 	instanceID := aws.ToString(result.Instances[0].InstanceId)
 
 	if dataVolumeID != "" {
-		svc := ec2.NewFromConfig(providerAws.AwsConfig)
 		waiter := ec2.NewInstanceRunningWaiter(svc)
 		if err := waiter.Wait(ctx, &ec2.DescribeInstancesInput{
 			InstanceIds: []string{instanceID},


### PR DESCRIPTION
## Context

This PR fixes three issues discovered while testing the data volume snapshot feature (introduced in #107, with NVMe resolution added in #121) on Graviton/Nitro instances (m7g, c7g) with Ubuntu AMIs. Without these fixes, booting from an EBS snapshot either fails or doesn't deliver the expected caching benefits.

All three fixes are scoped to the data volume code path — they only execute when `HasDataVolume()` is true or when a `SNAPSHOT_ID` is present. Zero behavior change for users without data volumes configured.

## Fixes

### 1. InstanceRunningWaiter before AttachVolume

**Problem:** #121 changed the data volume flow from `BlockDeviceMappings` on `RunInstances` to a separate `CreateVolume` + `AttachVolume` approach. However, `AttachVolume` is called immediately after `RunInstances` returns, while the instance is still in "pending" state. AWS requires "running" state for `AttachVolume`, causing `IncorrectState` errors on every boot.

**Fix:** Add `ec2.NewInstanceRunningWaiter` (5-minute timeout) before `attachDataVolume()`. On failure, cleans up both the instance and the orphaned volume.

### 2. Containerd bind mount in UserData

**Problem:** Docker 29+ uses the containerd snapshotter by default, storing all image layers at `/var/lib/containerd/` on the root volume — NOT at `/var/lib/docker/` where the EBS data volume is mounted. This means EBS snapshots don't capture Docker image layers, defeating the purpose of the snapshot feature.

**Fix:** After mounting the EBS volume at the configured mount path, the UserData script:
- Creates `.containerd-root/` on the EBS volume
- Bind-mounts it to `/var/lib/containerd`
- Adds an fstab entry for persistence across reboots

This ensures all Docker image layers are stored on the EBS volume and captured in snapshots.

### 3. Stale container cleanup on snapshot boot

**Problem:** When booting from a snapshot taken from a running workspace, Docker container metadata (names, network config) from the previous workspace is present on the EBS volume. When a new container with the same name is created, Docker rejects it with `exit status 125`.

**Fix:** In UserData, when `SNAPSHOT_ID` is set, remove stale container and network metadata before Docker starts:
```bash
if [ -n "$SNAPSHOT_ID" ] && [ -d "<mount_path>/containers" ]; then
  rm -rf "<mount_path>/containers"/*
  rm -rf "<mount_path>/network/files"/*
fi
```

## Testing

Tested end-to-end on `m7g.2xlarge` (Graviton ARM64) with Ubuntu 24.04 AMI:
- [x] Fresh boot with blank data volume — formats, mounts, containerd bind works
- [x] Golden snapshot creation — captures image layers + DB data via containerd bind
- [x] Snapshot boot — all images CACHED, stale containers cleaned, no exit 125
- [x] Boot without data volume configured — zero behavior change (all guards check `HasDataVolume()` / `SNAPSHOT_ID`)

## References

- #107 — Original data volume feature (merged)
- #121 — NVMe resolution + CreateVolume/AttachVolume refactor (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)