### PR TITLE
feat: add AWS_CUSTOM_USER_DATA option for pre-Docker OS configuration

### DIFF
--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -189,6 +189,7 @@ func buildOptionGroups() []OptionGroup {
 				"AWS_DATA_VOLUME_DEVICE",
 				"AWS_DATA_VOLUME_MOUNT_PATH",
 				"AWS_DATA_VOLUME_TYPE",
+				"AWS_CUSTOM_USER_DATA",
 			},
 		},
 		{
@@ -625,6 +626,13 @@ func buildOptions() Options {
 		"AWS_DATA_VOLUME_TYPE": {
 			Description: "EBS volume type for the secondary data volume (e.g. gp3, gp2, st1, sc1).",
 			Default:     "gp3",
+		},
+		"AWS_CUSTOM_USER_DATA": {
+			Description: "Custom shell commands to execute in the instance user-data script " +
+				"before Docker is installed. Runs as root. Useful for OS-level " +
+				"configuration such as patching APT sources or installing packages. " +
+				"Failures are logged but do not block SSH key injection or volume setup.",
+			Default: "",
 		},
 	}
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1605,9 +1605,28 @@ chmod 0700 /home/devpod/.ssh
 chmod 0600 /home/devpod/.ssh/authorized_keys
 chown -R devpod:devpod /home/devpod`
 
+	resultScript += customUserDataSnippet(config)
 	resultScript += dataVolumeMountScript(config)
 
 	return base64.StdEncoding.EncodeToString([]byte(resultScript)), nil
+}
+
+// customUserDataSnippet returns a shell snippet that executes the operator-
+// supplied custom user-data commands. Failures are logged but do not prevent
+// the rest of the user-data script (SSH setup, volume mounts) from running.
+func customUserDataSnippet(config *options.Options) string {
+	if config.CustomUserData == "" {
+		return ""
+	}
+
+	return fmt.Sprintf(`
+
+# --- Custom user-data (AWS_CUSTOM_USER_DATA) ---
+if ! ( %s ); then
+  echo "WARNING: custom user-data commands exited with non-zero status" >&2
+fi`,
+		config.CustomUserData,
+	)
 }
 
 // dataVolumeMountScript returns a shell snippet that resolves the data volume

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -39,6 +39,9 @@ var (
 	AWS_SESSION_TOKEN                   = "AWS_SESSION_TOKEN"
 	CUSTOM_AWS_CREDENTIAL_COMMAND       = "CUSTOM_AWS_CREDENTIAL_COMMAND"
 
+	// Custom user-data option (optional).
+	AWS_CUSTOM_USER_DATA = "AWS_CUSTOM_USER_DATA"
+
 	// Data volume options (all optional).
 	AWS_DATA_VOLUME_SNAPSHOT_ID = "AWS_DATA_VOLUME_SNAPSHOT_ID"
 	AWS_DATA_VOLUME_SIZE        = "AWS_DATA_VOLUME_SIZE"
@@ -75,6 +78,9 @@ type Options struct {
 	SecretAccessKey            string
 	SessionToken               string
 
+	// Custom shell commands injected into user-data before Docker installation
+	CustomUserData string
+
 	// Optional secondary data volume
 	DataVolumeSnapshotID string
 	DataVolumeSizeGB     int
@@ -96,6 +102,7 @@ func FromEnv(init, withFolder bool) (*Options, error) {
 
 	var err error
 	retOptions.CustomCredentialCommand = os.Getenv(CUSTOM_AWS_CREDENTIAL_COMMAND)
+	retOptions.CustomUserData = os.Getenv(AWS_CUSTOM_USER_DATA)
 
 	retOptions.MachineType, err = fromEnvOrError(AWS_INSTANCE_TYPE)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds a new optional provider option `AWS_CUSTOM_USER_DATA` that allows operators to inject custom shell commands into the EC2 instance user-data script. Commands run **as root** before Docker is installed, enabling OS-level setup that must happen early in the boot sequence.

### Motivation

Stock Ubuntu AMI images ship with APT sources configured over `http`. In environments where security groups block outbound HTTP traffic, `apt-get update` (triggered by DevPod's Docker installation) fails. The established way to patch the OS before any package operations is via EC2 user-data, but the provider had no hook for custom commands.

### What changed

| File | Change |
|------|--------|
| `pkg/options/options.go` | New `AWS_CUSTOM_USER_DATA` env var and `CustomUserData` field on `Options` |
| `hack/provider/main.go` | Expose `AWS_CUSTOM_USER_DATA` in the "AWS options" group with documentation |
| `pkg/aws/aws.go` | New `customUserDataSnippet()` helper injected into `GetInjectKeypairScript()` between SSH setup and data volume mount |

### Design decisions

- **Ordering**: Custom commands run after user/SSH key creation but before data volume mount and Docker installation — the earliest safe point where the OS is accessible.
- **Error handling**: Custom commands are wrapped in `if ! ( ... )` so failures log a warning but do not prevent SSH key injection or volume setup from completing. This avoids bricking instances due to a misconfigured option.
- **Backwards compatible**: Empty default; existing users see no change in behavior.
- **Consistent with existing patterns**: Follows the same approach as `CUSTOM_AWS_CREDENTIAL_COMMAND` — a string option that holds shell commands executed at runtime.

### Example usage

```bash
devpod provider set-options aws \
  -o AWS_CUSTOM_USER_DATA='sed -i "s|http://|https://|g" /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true'
```

## Test plan

- [ ] Verify `go vet ./...` and `go test ./...` pass (confirmed locally)
- [ ] Deploy a workspace **without** `AWS_CUSTOM_USER_DATA` set — behavior identical to before
- [ ] Deploy a workspace **with** `AWS_CUSTOM_USER_DATA` set to an APT source patch — confirm sources are patched and Docker installs successfully
- [ ] Deploy a workspace with a deliberately failing custom command — confirm instance still boots with SSH and volumes intact, warning visible in cloud-init logs


Made with [Cursor](https://cursor.com)