### PR TITLE
feat: add user-data hooks for EC2 instance initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/skevetter/devpod-provider-aws
 go 1.25.8
 
 require (
+	al.essio.dev/pkg/shellescape v1.6.0
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.14
@@ -15,11 +16,11 @@ require (
 	github.com/skevetter/devpod v0.21.1
 	github.com/skevetter/log v0.0.0-20260106023547-bfd26ab1367c
 	github.com/spf13/cobra v1.10.2
+	github.com/stretchr/testify v1.11.1
 	golang.org/x/crypto v0.50.0
 )
 
 require (
-	al.essio.dev/pkg/shellescape v1.6.0 // indirect
 	cel.dev/expr v0.25.1 // indirect
 	github.com/AlecAivazis/survey/v2 v2.3.7 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
@@ -147,6 +148,7 @@ require (
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.3 // indirect
 	k8s.io/apimachinery v0.35.3 // indirect
 	k8s.io/apiserver v0.35.3 // indirect

--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -189,6 +189,8 @@ func buildOptionGroups() []OptionGroup {
 				"AWS_DATA_VOLUME_DEVICE",
 				"AWS_DATA_VOLUME_MOUNT_PATH",
 				"AWS_DATA_VOLUME_TYPE",
+				"AWS_HOOK_POST_SSH",
+				"AWS_HOOK_POST_VOLUME",
 			},
 		},
 		{
@@ -625,6 +627,18 @@ func buildOptions() Options {
 		"AWS_DATA_VOLUME_TYPE": {
 			Description: "EBS volume type for the secondary data volume (e.g. gp3, gp2, st1, sc1).",
 			Default:     "gp3",
+		},
+		"AWS_HOOK_POST_SSH": {
+			Description: "Commands or S3 script (s3://bucket/path.sh) to run after " +
+				"user creation and SSH key injection, before data volume mount. " +
+				"Runs as root. Failures are logged but do not halt instance setup.",
+			Default: "",
+		},
+		"AWS_HOOK_POST_VOLUME": {
+			Description: "Commands or S3 script (s3://bucket/path.sh) to run after " +
+				"data volume mount, at the end of the user-data script. " +
+				"Runs as root. Failures are logged but do not halt instance setup.",
+			Default: "",
 		},
 	}
 }

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -1605,7 +1605,9 @@ chmod 0700 /home/devpod/.ssh
 chmod 0600 /home/devpod/.ssh/authorized_keys
 chown -R devpod:devpod /home/devpod`
 
+	resultScript += hookSnippet("post-ssh", config.HookPostSSH)
 	resultScript += dataVolumeMountScript(config)
+	resultScript += hookSnippet("post-volume", config.HookPostVolume)
 
 	return base64.StdEncoding.EncodeToString([]byte(resultScript)), nil
 }

--- a/pkg/aws/hook.go
+++ b/pkg/aws/hook.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+
+	"al.essio.dev/pkg/shellescape"
+)
+
+const (
+	hookTmpPrefix = "/tmp/devpod-hook-"
+	hookLogPrefix = "/var/log/devpod-hook-"
+)
+
+// isS3Reference returns true if the value is an S3 URI (case-sensitive s3:// prefix).
+func isS3Reference(value string) bool {
+	return strings.HasPrefix(value, "s3://")
+}
+
+// hookSnippet returns a shell snippet that executes a user-data hook.
+// If value is empty, returns "". If value starts with s3://, generates a
+// snippet that fetches the script from S3. Otherwise, base64-encodes the
+// value and generates a snippet that decodes and executes it.
+// All output is logged to /var/log/devpod-hook-<name>.log.
+// Failures emit a warning to stderr but do not halt the script.
+func hookSnippet(name string, value string) string {
+	if value == "" {
+		return ""
+	}
+
+	tmpFile := hookTmpPrefix + name + ".sh"
+	logFile := hookLogPrefix + name + ".log"
+
+	if isS3Reference(value) {
+		return s3HookSnippet(name, value, tmpFile, logFile)
+	}
+
+	return inlineHookSnippet(name, value, tmpFile, logFile)
+}
+
+func inlineHookSnippet(name, commands, tmpFile, logFile string) string {
+	encoded := base64.StdEncoding.EncodeToString([]byte(commands))
+
+	return fmt.Sprintf(`
+
+# --- Hook: %s ---
+echo "%s" | base64 -d > %s
+chmod +x %s
+/bin/sh %s >> %s 2>&1 || echo "WARNING: %s hook failed (see %s)" >&2
+rm -f %s`,
+		name,
+		encoded,
+		tmpFile,
+		tmpFile,
+		tmpFile, logFile,
+		name, logFile,
+		tmpFile,
+	)
+}
+
+func s3HookSnippet(name, s3URI, tmpFile, logFile string) string {
+	safeURI := shellescape.Quote(s3URI)
+
+	return fmt.Sprintf(`
+
+# --- Hook: %s ---
+if aws s3 cp %s %s >> %s 2>&1; then
+  chmod +x %s
+  /bin/sh %s >> %s 2>&1 || echo "WARNING: %s hook failed (see %s)" >&2
+else
+  echo "WARNING: %s hook S3 download failed (see %s)" >&2
+fi
+rm -f %s`,
+		name,
+		safeURI, tmpFile, logFile,
+		tmpFile,
+		tmpFile, logFile,
+		name, logFile,
+		name, logFile,
+		tmpFile,
+	)
+}

--- a/pkg/aws/hook_test.go
+++ b/pkg/aws/hook_test.go
@@ -1,0 +1,113 @@
+package aws
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type HookSuite struct {
+	suite.Suite
+}
+
+func TestHookSuite(t *testing.T) {
+	suite.Run(t, new(HookSuite))
+}
+
+func (s *HookSuite) TestIsS3Reference() {
+	tests := []struct {
+		name     string
+		value    string
+		expected bool
+	}{
+		{name: "s3 URI", value: "s3://bucket/script.sh", expected: true},
+		{name: "s3 URI with deep path", value: "s3://bucket/a/b/c.sh", expected: true},
+		{name: "s3 URI minimal", value: "s3://b", expected: true},
+		{name: "inline command", value: "apt-get update", expected: false},
+		{name: "empty string", value: "", expected: false},
+		{name: "uppercase S3", value: "S3://bucket", expected: false},
+		{name: "s3 without colon-slash-slash", value: "s3:bucket", expected: false},
+		{name: "https URL", value: "https://example.com/script.sh", expected: false},
+	}
+
+	for _, tt := range tests {
+		s.Run(tt.name, func() {
+			assert.Equal(s.T(), tt.expected, isS3Reference(tt.value))
+		})
+	}
+}
+
+func (s *HookSuite) TestHookSnippetEmpty() {
+	result := hookSnippet("post-ssh", "")
+	assert.Equal(s.T(), "", result)
+}
+
+func (s *HookSuite) TestHookSnippetInline() {
+	result := hookSnippet("post-ssh", "apt-get update")
+
+	assert.Contains(s.T(), result, "# --- Hook: post-ssh ---")
+	assert.Contains(s.T(), result, "base64 -d > /tmp/devpod-hook-post-ssh.sh")
+	assert.Contains(s.T(), result,
+		"/bin/sh /tmp/devpod-hook-post-ssh.sh >> /var/log/devpod-hook-post-ssh.log 2>&1")
+	assert.Contains(s.T(), result, "rm -f /tmp/devpod-hook-post-ssh.sh")
+
+	// Verify base64 round-trip: the encoded value should decode back to the original
+	encoded := base64.StdEncoding.EncodeToString([]byte("apt-get update"))
+	assert.Contains(s.T(), result, encoded)
+}
+
+func (s *HookSuite) TestHookSnippetInlineWithPercentChars() {
+	input := `awk '{print $1 "%" $2}'`
+	result := hookSnippet("post-ssh", input)
+
+	// Base64 encoding eliminates the % problem entirely
+	encoded := base64.StdEncoding.EncodeToString([]byte(input))
+	assert.Contains(s.T(), result, encoded)
+}
+
+func (s *HookSuite) TestHookSnippetInlineMultiLine() {
+	input := "line1\nline2\nline3"
+	result := hookSnippet("post-ssh", input)
+
+	encoded := base64.StdEncoding.EncodeToString([]byte(input))
+	assert.Contains(s.T(), result, encoded)
+}
+
+func (s *HookSuite) TestHookSnippetS3() {
+	result := hookSnippet("post-ssh", "s3://my-bucket/scripts/setup.sh")
+
+	assert.Contains(s.T(), result, "# --- Hook: post-ssh ---")
+	assert.Contains(s.T(), result,
+		"aws s3 cp s3://my-bucket/scripts/setup.sh /tmp/devpod-hook-post-ssh.sh")
+	assert.Contains(s.T(), result,
+		"/bin/sh /tmp/devpod-hook-post-ssh.sh >> /var/log/devpod-hook-post-ssh.log 2>&1")
+	assert.Contains(s.T(), result, "WARNING: post-ssh hook S3 download failed")
+	assert.Contains(s.T(), result, "rm -f /tmp/devpod-hook-post-ssh.sh")
+}
+
+func (s *HookSuite) TestHookSnippetS3DeepPath() {
+	result := hookSnippet("post-volume", "s3://bucket/a/b/c.sh")
+
+	assert.Contains(s.T(), result,
+		"aws s3 cp s3://bucket/a/b/c.sh /tmp/devpod-hook-post-volume.sh")
+	assert.Contains(s.T(), result, "/var/log/devpod-hook-post-volume.log")
+}
+
+func (s *HookSuite) TestHookSnippetS3ShellEscape() {
+	// URI with shell metacharacters must be escaped
+	result := hookSnippet("post-ssh", "s3://bucket/$(whoami).sh")
+
+	assert.Contains(s.T(), result,
+		"aws s3 cp 's3://bucket/$(whoami).sh'")
+	assert.NotContains(s.T(), result, `"s3://bucket/$(whoami).sh"`)
+}
+
+func (s *HookSuite) TestHookSnippetHookNameInOutput() {
+	result := hookSnippet("post-volume", "echo hello")
+
+	assert.Contains(s.T(), result, "# --- Hook: post-volume ---")
+	assert.Contains(s.T(), result, "/tmp/devpod-hook-post-volume.sh")
+	assert.Contains(s.T(), result, "/var/log/devpod-hook-post-volume.log")
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -39,6 +39,10 @@ var (
 	AWS_SESSION_TOKEN                   = "AWS_SESSION_TOKEN"
 	CUSTOM_AWS_CREDENTIAL_COMMAND       = "CUSTOM_AWS_CREDENTIAL_COMMAND"
 
+	// User-data hook options (optional).
+	AWS_HOOK_POST_SSH    = "AWS_HOOK_POST_SSH"
+	AWS_HOOK_POST_VOLUME = "AWS_HOOK_POST_VOLUME"
+
 	// Data volume options (all optional).
 	AWS_DATA_VOLUME_SNAPSHOT_ID = "AWS_DATA_VOLUME_SNAPSHOT_ID"
 	AWS_DATA_VOLUME_SIZE        = "AWS_DATA_VOLUME_SIZE"
@@ -75,6 +79,10 @@ type Options struct {
 	SecretAccessKey            string
 	SessionToken               string
 
+	// User-data hooks executed during instance initialization
+	HookPostSSH    string
+	HookPostVolume string
+
 	// Optional secondary data volume
 	DataVolumeSnapshotID string
 	DataVolumeSizeGB     int
@@ -96,6 +104,8 @@ func FromEnv(init, withFolder bool) (*Options, error) {
 
 	var err error
 	retOptions.CustomCredentialCommand = os.Getenv(CUSTOM_AWS_CREDENTIAL_COMMAND)
+	retOptions.HookPostSSH = os.Getenv(AWS_HOOK_POST_SSH)
+	retOptions.HookPostVolume = os.Getenv(AWS_HOOK_POST_VOLUME)
 
 	retOptions.MachineType, err = fromEnvOrError(AWS_INSTANCE_TYPE)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds `AWS_HOOK_POST_SSH` and `AWS_HOOK_POST_VOLUME` provider options for executing custom commands during EC2 instance boot
- Supports inline shell commands and S3 script references (`s3://bucket/path.sh`)
- Uses parse-isolated temp-file execution: inline commands are base64-encoded, S3 scripts are fetched via `aws s3 cp` — user commands never appear inline in the parent user-data script
- Failures are logged to `/var/log/devpod-hook-<name>.log` but do not halt instance setup

### Boot sequence

```
1. User creation + sudo setup
2. SSH key injection
3. ── post-ssh hook ──
4. Data volume mount + fstab
5. ── post-volume hook ──
6. [cloud-init done, DevPod agent connects]
```

### Example usage

```bash
# Inline — patch APT sources before Docker install
devpod provider set-options aws \
  -o AWS_HOOK_POST_SSH='sed -i "s|http://|https://|g" /etc/apt/sources.list'

# S3 — run a security hardening script after volume mount
devpod provider set-options aws \
  -o AWS_HOOK_POST_VOLUME='s3://my-corp-bucket/hardening/cis-ubuntu.sh'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extensible AWS instance hooks: configurable post-SSH and post-volume scripts (inline or remote), run as root, logged, and non-blocking to instance setup; configurable via environment variables.

* **Tests**
  * Added comprehensive tests covering hook detection, inline and remote hook handling, logging, and cleanup.

* **Chores**
  * Updated project dependency declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->