### PR TITLE
fix: allow feat commits to bump minor version pre-1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,8 +4,7 @@
     "packages": {
         ".": {
             "changelog-path": "CHANGELOG.md",
-            "bump-minor-pre-major": true,
-            "bump-patch-for-minor-pre-major": true
+            "bump-minor-pre-major": true
         }
     }
 }


### PR DESCRIPTION
- Removes `bump-patch-for-minor-pre-major` from release-please config
- With this flag set, `feat:` commits were only bumping the patch version while pre-1.0 (e.g. 0.5.8 → 0.5.9 instead of 0.5.8 → 0.6.0)
- `bump-minor-pre-major` is retained to prevent breaking changes from bumping to 1.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release versioning configuration to adjust patch version handling during pre-major release cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->