### PR TITLE
docs: document all provider options in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,20 +33,80 @@ You'll need to wait for the machine and environment setup.
 
 ### Customize the VM Instance
 
-This provider has the following options
+This provider has the following options.
 
-| NAME                     | REQUIRED | DESCRIPTION                                                       | DEFAULT                                                               |
-| ------------------------ | -------- | ----------------------------------------------------------------- | --------------------------------------------------------------------- |
-| AWS_AMI                  | false    | The disk image to use.                                            | latest ubuntu in the region with proper architecture for the instance |
-| AWS_DISK_SIZE            | false    | The disk size to use.                                             | 40                                                                    |
-| AWS_ROOT_DEVICE          | false    | The ID of the root device.                                        | The `RootDeviceName` property of the AMI, or `/dev/sda1` if undefined |
-| AWS_INSTANCE_TYPE        | false    | The machine type to use.                                          | c5.xlarge                                                             |
-| AWS_REGION               | true     | The aws cloud region to create the VM                             |                                                                       |
-| AWS_VPC_ID               | false    | The vpc id to use.                                                |                                                                       |
-| AWS_SECURITY_GROUP_ID    | false    | The security group ID is a comma separated list of IDs for the VM | created if not specified                                              |
-| AWS_SUBNET_ID            | false    | The subnet ID for the VM                                          | created if not specified                                              |
-| AWS_INSTANCE_TAGS        | false    | Additional flags for the VM in the form of "Name=XXX,Value=YYY "  |                                                                       |
-| AWS_INSTANCE_PROFILE_ARN | false    | The ARN of the instance profile to use for the VM                 | created if not specified                                              |
+#### Credentials
+
+| NAME                          | REQUIRED | DESCRIPTION                                                                                                                                                                    | DEFAULT   |
+| ----------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| AWS_ACCESS_KEY_ID             | false    | The AWS access key id.                                                                                                                                                          |           |
+| AWS_SECRET_ACCESS_KEY         | false    | The AWS secret access key.                                                                                                                                                      |           |
+| AWS_SESSION_TOKEN             | false    | The AWS session token for temporary credentials.                                                                                                                               |           |
+| AWS_PROFILE                   | false    | The AWS profile name to use.                                                                                                                                                    | `default` |
+| CUSTOM_AWS_CREDENTIAL_COMMAND | false    | Shell command executed to get AWS credentials. Must return JSON with `AccessKeyID` (required), `SecretAccessKey` (required) and `SessionToken` (optional).                     |           |
+
+#### Instance & networking
+
+| NAME                     | REQUIRED | DESCRIPTION                                                                                                                                                  | DEFAULT                                                               |
+| ------------------------ | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- |
+| AWS_REGION               | true     | The AWS cloud region to create the VM in (e.g. `us-west-1`).                                                                                                  |                                                                       |
+| AWS_AMI                  | false    | The disk image to use.                                                                                                                                       | latest ubuntu in the region with proper architecture for the instance |
+| AWS_DISK_SIZE            | false    | The root disk size to use (in GB).                                                                                                                           | 40                                                                    |
+| AWS_ROOT_DEVICE          | false    | The root device of the disk image.                                                                                                                           | The `RootDeviceName` property of the AMI, or `/dev/sda1` if undefined |
+| AWS_INSTANCE_TYPE        | false    | The machine type to use.                                                                                                                                     | c5.xlarge                                                             |
+| AWS_VPC_ID               | false    | The vpc id to use.                                                                                                                                           |                                                                       |
+| AWS_SUBNET_ID            | false    | The subnet id to use. Multiple can be specified comma-separated; by default the one with the most available IPs is chosen. Overridden by AWS_AVAILABILITY_ZONE. | created if not specified                                              |
+| AWS_SECURITY_GROUP_ID    | false    | The security group id to use. Multiple can be specified comma-separated.                                                                                     | created if not specified                                              |
+| AWS_AVAILABILITY_ZONE    | false    | The availability zone to choose a subnet out of the desired zone.                                                                                            |                                                                       |
+| AWS_INSTANCE_TAGS        | false    | Additional tags for the instance in the form of `Name=XXX,Value=YYY Name=ZZZ,Value=WWW`.                                                                     |                                                                       |
+| AWS_INSTANCE_PROFILE_ARN | false    | The ARN of the instance profile to use for the VM.                                                                                                           | created if not specified                                              |
+| AWS_USE_NESTED_VIRTUALIZATION | false | If `true`, nested virtualization is enabled for the EC2 instance.                                                                                           | false                                                                 |
+
+#### Spot instances
+
+| NAME                   | REQUIRED | DESCRIPTION                                                                                                                              | DEFAULT      |
+| ---------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| AWS_USE_SPOT_INSTANCE  | false    | Prefer Spot instead of On-Demand instances.                                                                                             | false        |
+| AWS_SPOT_INSTANCE_TYPE | false    | The spot instance request type. `persistent` keeps the request active after interruption, `one-time` is a single fulfillment attempt. Only used when AWS_USE_SPOT_INSTANCE is true. | `persistent` |
+
+#### Connectivity
+
+| NAME                                | REQUIRED | DESCRIPTION                                                                                                                                                                                | DEFAULT |
+| ----------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| AWS_USE_INSTANCE_CONNECT_ENDPOINT   | false    | If `true`, connect to the EC2 instance via the default instance connect endpoint for the current subnet.                                                                                  | false   |
+| AWS_INSTANCE_CONNECT_ENDPOINT_ID    | false    | Specify which instance connect endpoint to use. Only works with AWS_USE_INSTANCE_CONNECT_ENDPOINT enabled.                                                                                |         |
+| AWS_USE_SESSION_MANAGER             | false    | If `true`, connect to the EC2 instance via AWS Session Manager.                                                                                                                           | false   |
+| AWS_KMS_KEY_ARN_FOR_SESSION_MANAGER | false    | The KMS key ARN to use for AWS Session Manager.                                                                                                                                          |         |
+| AWS_USE_ROUTE53                     | false    | If `true`, create a Route53 record for the machine's IP and use that hostname on connect. Zone is configured by AWS_ROUTE53_ZONE_NAME, or looked up by the tag `devpod=devpod`.          | false   |
+| AWS_ROUTE53_ZONE_NAME               | false    | The zone name of a Route53 hosted zone to use for the machine's DNS name.                                                                                                                |         |
+
+#### Secondary data volume
+
+| NAME                        | REQUIRED | DESCRIPTION                                                                                                                                          | DEFAULT     |
+| --------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| AWS_DATA_VOLUME_SNAPSHOT_ID | false    | EBS snapshot ID to restore as a secondary data volume. Useful for skipping dependency installs and lengthy setup.                                   |             |
+| AWS_DATA_VOLUME_SIZE        | false    | Size in GB for the secondary data volume. Required for new blank volumes; defaults to the snapshot size when restoring from a snapshot.             |             |
+| AWS_DATA_VOLUME_DEVICE      | false    | Device name for the secondary data volume.                                                                                                          | `/dev/xvdf` |
+| AWS_DATA_VOLUME_MOUNT_PATH  | false    | Mount path for the secondary data volume inside the instance.                                                                                       | `/data`     |
+| AWS_DATA_VOLUME_TYPE        | false    | EBS volume type for the secondary data volume (e.g. `gp3`, `gp2`, `st1`, `sc1`).                                                                    | `gp3`       |
+
+#### User-data hooks
+
+These run as `root` during instance initialization. The value can be inline shell commands or an S3 script reference (`s3://bucket/path.sh`). Failures are logged to `/var/log/devpod-hook-<name>.log` but do not halt instance setup.
+
+| NAME                 | REQUIRED | DESCRIPTION                                                                                              | DEFAULT |
+| -------------------- | -------- | ------------------------------------------------------------------------------------------------------- | ------- |
+| AWS_HOOK_POST_SSH    | false    | Commands or S3 script to run after user creation and SSH key injection, before the data volume mount.   |         |
+| AWS_HOOK_POST_VOLUME | false    | Commands or S3 script to run after the data volume mount, at the end of the user-data script.           |         |
+
+#### Agent & DevPod behavior
+
+| NAME                      | REQUIRED | DESCRIPTION                                                          | DEFAULT                  |
+| ------------------------- | -------- | ------------------------------------------------------------------- | ------------------------ |
+| INACTIVITY_TIMEOUT        | false    | Automatically stop the VM after the inactivity period.              | 10m                      |
+| INJECT_GIT_CREDENTIALS    | false    | Whether DevPod should inject git credentials into the remote host.  | true                     |
+| INJECT_DOCKER_CREDENTIALS | false    | Whether DevPod should inject docker credentials into the remote host. | true                   |
+| AGENT_PATH                | false    | The path where to inject the DevPod agent to.                       | /var/lib/toolbox/devpod  |
 
 You will need a user profile able to:
   - Create/Start/Stop/Destroy instances


### PR DESCRIPTION
## Summary
- Expand the README options table, which previously documented only 10 of the 36 options the provider actually defines.
- Reorganize options into grouped sections: Credentials, Instance & networking, Spot instances, Connectivity, Secondary data volume, User-data hooks, and Agent & DevPod behavior.
- Correct descriptions/defaults to match the source of truth in `hack/provider/main.go` (e.g. `AWS_PROFILE` default `default`, comma-separated subnet/security-group behavior, `AWS_AVAILABILITY_ZONE`, nested virtualization, spot, Session Manager, Route53, data volume, and hook options).

## Test plan
- [ ] Render README on GitHub and confirm all tables display correctly.
- [ ] Spot-check option names/defaults against `hack/provider/main.go` and/or `task build:provider:dev` output.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced AWS provider options documentation with improved organization and expanded coverage. Added comprehensive sections for credentials, instance networking, spot instances, connectivity, secondary data volumes, user-data hooks, and agent behavior. All options now include detailed descriptions and default values for streamlined configuration and reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->