### PR TITLE
Respect static AWS credentials over shared profiles

### DIFF
--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -240,7 +240,9 @@ func buildOptions() Options {
 		},
 		"AWS_PROFILE": {
 			Description: "The aws profile name to use",
-			Command:     `if [ "${AWS_PROFILE:-}" = "__unset__" ]; then printf ""; elif [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then printf ""; else printf "%s" "${AWS_PROFILE:-default}"; fi`,
+			Command: `if [ "${AWS_PROFILE:-}" = "__unset__" ] || ` +
+				`{ [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; } || ` +
+				`[ -n "${CUSTOM_AWS_CREDENTIAL_COMMAND:-}" ]; then printf ""; else printf "%s" "${AWS_PROFILE:-default}"; fi`,
 		},
 		"AWS_DISK_SIZE": {
 			Description: "The disk size to use.",

--- a/hack/provider/main.go
+++ b/hack/provider/main.go
@@ -240,7 +240,7 @@ func buildOptions() Options {
 		},
 		"AWS_PROFILE": {
 			Description: "The aws profile name to use",
-			Command:     `printf "%s" "${AWS_PROFILE:-default}"`,
+			Command:     `if [ "${AWS_PROFILE:-}" = "__unset__" ]; then printf ""; elif [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then printf ""; else printf "%s" "${AWS_PROFILE:-default}"; fi`,
 		},
 		"AWS_DISK_SIZE": {
 			Description: "The disk size to use.",

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -155,7 +155,6 @@ func buildConfigOptions(
 	case options.AccessKeyID != "" && options.SecretAccessKey != "":
 		log.Debugf("using provided AWS credentials")
 		_ = os.Unsetenv("AWS_PROFILE")
-		_ = os.Unsetenv("AWS_DEFAULT_PROFILE")
 		opts = append(opts, awsConfig.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{
 				AccessKeyID:     options.AccessKeyID,
@@ -167,7 +166,6 @@ func buildConfigOptions(
 		opts = append(opts, awsConfig.WithSharedCredentialsFiles([]string{}))
 	case options.CustomCredentialCommand != "":
 		_ = os.Unsetenv("AWS_PROFILE")
-		_ = os.Unsetenv("AWS_DEFAULT_PROFILE")
 		creds, err := executeCredentialCommand(ctx, options.CustomCredentialCommand, log)
 		if err != nil {
 			return nil, fmt.Errorf("custom credential command: %w", err)
@@ -189,7 +187,6 @@ func buildConfigOptions(
 		} else {
 			log.Debugf("using default AWS credential chain")
 			_ = os.Unsetenv("AWS_PROFILE")
-			_ = os.Unsetenv("AWS_DEFAULT_PROFILE")
 		}
 	}
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -154,6 +154,8 @@ func buildConfigOptions(
 	switch {
 	case options.AccessKeyID != "" && options.SecretAccessKey != "":
 		log.Debugf("using provided AWS credentials")
+		_ = os.Unsetenv("AWS_PROFILE")
+		_ = os.Unsetenv("AWS_DEFAULT_PROFILE")
 		opts = append(opts, awsConfig.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{
 				AccessKeyID:     options.AccessKeyID,
@@ -164,6 +166,8 @@ func buildConfigOptions(
 		opts = append(opts, awsConfig.WithSharedConfigFiles([]string{}))
 		opts = append(opts, awsConfig.WithSharedCredentialsFiles([]string{}))
 	case options.CustomCredentialCommand != "":
+		_ = os.Unsetenv("AWS_PROFILE")
+		_ = os.Unsetenv("AWS_DEFAULT_PROFILE")
 		creds, err := executeCredentialCommand(ctx, options.CustomCredentialCommand, log)
 		if err != nil {
 			return nil, fmt.Errorf("custom credential command: %w", err)
@@ -176,10 +180,16 @@ func buildConfigOptions(
 		opts = append(opts, awsConfig.WithSharedCredentialsFiles([]string{}))
 	default:
 		profile := os.Getenv("AWS_PROFILE")
+		if profile == "__unset__" {
+			profile = ""
+		}
 		if profile != "" {
 			log.Debugf("using AWS profile %s", profile)
+			opts = append(opts, awsConfig.WithSharedConfigProfile(profile))
 		} else {
 			log.Debugf("using default AWS credential chain")
+			_ = os.Unsetenv("AWS_PROFILE")
+			_ = os.Unsetenv("AWS_DEFAULT_PROFILE")
 		}
 	}
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -154,7 +154,6 @@ func buildConfigOptions(
 	switch {
 	case options.AccessKeyID != "" && options.SecretAccessKey != "":
 		log.Debugf("using provided AWS credentials")
-		_ = os.Unsetenv("AWS_PROFILE")
 		opts = append(opts, awsConfig.WithCredentialsProvider(credentials.StaticCredentialsProvider{
 			Value: aws.Credentials{
 				AccessKeyID:     options.AccessKeyID,
@@ -165,7 +164,6 @@ func buildConfigOptions(
 		opts = append(opts, awsConfig.WithSharedConfigFiles([]string{}))
 		opts = append(opts, awsConfig.WithSharedCredentialsFiles([]string{}))
 	case options.CustomCredentialCommand != "":
-		_ = os.Unsetenv("AWS_PROFILE")
 		creds, err := executeCredentialCommand(ctx, options.CustomCredentialCommand, log)
 		if err != nil {
 			return nil, fmt.Errorf("custom credential command: %w", err)


### PR DESCRIPTION
## What's in this PR?

Make AWS profile handling stop interfering with explicit or custom provider credentials.

- suppress `AWS_PROFILE` in the generated provider manifest when static access key options are present
- allow `AWS_PROFILE=__unset__` to clear profile-based resolution explicitly

## QA Instructions

1. Run `devpod provider add` with `-o AWS_ACCESS_KEY_ID=...` and `-o AWS_SECRET_ACCESS_KEY=...` and verify provider setup completes without shared profile errors.
2. Run `devpod provider add` with global AWS credentials present and `-o AWS_PROFILE=__unset__` and verify provider setup still completes.

## References

- https://github.com/skevetter/devpod-provider-aws/issues/111

Co-Authored-By: Amplify 2.2.0 <amplify@getjobber.com>