### PR TITLE
fix: honor DEVPOD_LOG_LEVEL / DEVPOD_DEBUG so provider debug logs are visible

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,10 +19,6 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 
 		PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
-			// Honor the debug signals devpod passes to provider processes.
-			// DEVPOD_LOG_LEVEL is always set (encodes --silent/--debug); DEVPOD_DEBUG
-			// is an explicit boolean set on the RunCommand/init path in debug mode.
-			// Mirrors devpod's own agent (cmd/agent/agent.go).
 			if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {
 				log.Default.SetLevel(lvl)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 
+	"github.com/sirupsen/logrus"
 	"github.com/skevetter/log"
 	"github.com/spf13/cobra"
 	"golang.org/x/crypto/ssh"
@@ -18,6 +19,17 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 
 		PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
+			// Honor the debug signals devpod passes to provider processes.
+			// DEVPOD_LOG_LEVEL is always set (encodes --silent/--debug); DEVPOD_DEBUG
+			// is an explicit boolean set on the RunCommand/init path in debug mode.
+			// Mirrors devpod's own agent (cmd/agent/agent.go).
+			if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {
+				log.Default.SetLevel(lvl)
+			}
+			if os.Getenv("DEVPOD_DEBUG") == "true" {
+				log.Default.SetLevel(logrus.DebugLevel)
+			}
+
 			log.Default.MakeRaw()
 
 			return nil


### PR DESCRIPTION
## Problem

Provider `log.Debugf(...)` output never appears, even when devpod is run with `--debug`. For example, running:

```
devpod provider add aws --debug -o AWS_REGION=us-east-1
```

shows none of the debug lines from `pkg/aws/aws.go` (e.g. `configuring AWS SDK for region ...`, `using provided AWS credentials`), making it hard to debug credential/config issues.

## Reproduce

1. Add the provider with debug enabled: `devpod provider add aws --debug` (this runs the provider's `init` subcommand).
2. Observe that no `Debugf` lines are emitted — only `info`/`error` output.

## Root cause

- The provider logger `log.Default` (`github.com/skevetter/log`) is created at `logrus.InfoLevel`. `Debugf` is gated on `level >= DebugLevel`, so at Info level it is dropped.
- `cmd/root.go`'s `PersistentPreRunE` only calls `log.Default.MakeRaw()` (sets output format) and **never raises the level**, so it ignores the debug signals devpod passes.
- devpod already provides those signals to every provider process — `DEVPOD_LOG_LEVEL` (always) and `DEVPOD_DEBUG=true` (on the `init`/`RunCommand` path when in debug mode) — but the provider wasn't consuming them.

Because the gap is in the root command's `PersistentPreRunE`, it affects **all** subcommands (`init`, `create`, `command`, etc.), not just `provider add`.

## Fix

Honor the debug env vars in the root `PersistentPreRunE`, mirroring devpod's own agent (`cmd/agent/agent.go`):

```go
if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {
    log.Default.SetLevel(lvl)
}
if os.Getenv("DEVPOD_DEBUG") == "true" {
    log.Default.SetLevel(logrus.DebugLevel)
}
```

`DEVPOD_LOG_LEVEL` encodes `--silent`/`--debug` and is set on every provider invocation; `DEVPOD_DEBUG=true` is the explicit boolean the agent keys off. With neither set, `ParseLevel("")` errors and the level stays at the `InfoLevel` default — no behavior change outside debug mode.

## Prior art

The Kubernetes provider already handles this in its root command via the same `DEVPOD_DEBUG` check: https://github.com/skevetter/devpod-provider-kubernetes/blob/bbe4b9aea8c68a2281bc93298630ba6dec5a152a/cmd/root.go#L22. This PR brings the AWS provider in line with that pattern (and additionally honors `DEVPOD_LOG_LEVEL`).

## Verification

Building the dev provider and running `devpod provider add aws --debug` now surfaces the provider's debug lines; running without `--debug` keeps them hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Provider processes now honor the configured DevPod log level.
  * Debug mode enables more detailed diagnostic logging for improved troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->