### PR TITLE
fix: re-add DEVPOD_LOG_LEVEL/DEVPOD_DEBUG support with logs routed to stderr

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,13 @@ func NewRootCmd() *cobra.Command {
 			// stderr so enabling debug output never corrupts that channel.
 			log.Default = log.NewStreamLogger(os.Stderr, os.Stderr, logrus.InfoLevel)
 
+			if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {
+				log.Default.SetLevel(lvl)
+			}
+			if os.Getenv("DEVPOD_DEBUG") == "true" {
+				log.Default.SetLevel(logrus.DebugLevel)
+			}
+
 			log.Default.MakeRaw()
 
 			return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,11 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 
 		PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
+			// Provider stdout is a machine-readable channel that devpod parses
+			// (status, describe, command/SSH). Send all diagnostic logging to
+			// stderr so enabling debug output never corrupts that channel.
+			log.Default = log.NewStreamLogger(os.Stderr, os.Stderr, logrus.InfoLevel)
+
 			if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {
 				log.Default.SetLevel(lvl)
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,9 +19,6 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:  true,
 
 		PersistentPreRunE: func(cobraCmd *cobra.Command, args []string) error {
-			// Provider stdout is a machine-readable channel that devpod parses
-			// (status, describe, command/SSH). Send all diagnostic logging to
-			// stderr so enabling debug output never corrupts that channel.
 			log.Default = log.NewStreamLogger(os.Stderr, os.Stderr, logrus.InfoLevel)
 
 			if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {


### PR DESCRIPTION
Re-adds the provider debug logging that was reverted in #270 (originally #254), this time without breaking `devpod up`. Rebased on current `main`.

## Background

#254 enabled provider debug logging via `DEVPOD_LOG_LEVEL` / `DEVPOD_DEBUG`, but it caused `devpod up` to fail with:

```
fatal error parsing status: 'CREATING NEW AWS PROVIDER
CONFIGURING AWS SDK FOR REGION US-EAST-1
...
BUSY' unrecognized status, needs to be one of: [Running Busy Stopped NotFound]
```

so it was reverted in #270. This PR brings the feature back with the underlying issue fixed.

## Root cause

devpod treats a provider's **stdout** as a machine-readable channel and parses it:

- `status` must print exactly one of `Running/Busy/Stopped/NotFound` — devpod captures stdout into a buffer and runs `client.ParseStatus(stdout)` (which trims + upper-cases the whole blob; hence the ALL-CAPS text in the error).
- `describe` prints JSON to stdout; `command` uses stdout for the SSH stream.
- Diagnostics belong on **stderr**, which devpod streams to the user at info level (`stderr: io.MultiWriter(stderr, s.log.Writer(logrus.InfoLevel, true))` in devpod's machine client).

But `skevetter/log` routes **info/debug to stdout** (only warn/error go to stderr). With only `Debugf` calls at the default Info level, stdout stayed clean by luck. Raising the level to Debug put those log lines on stdout alongside the status word, so `ParseStatus` received `"<debug logs>...Busy"` and failed.

## Fix

In the root `PersistentPreRunE`, point the provider logger at stderr before applying the level, so stdout stays a clean protocol channel:

```go
// Provider stdout is a machine-readable channel that devpod parses
// (status, describe, command/SSH). Send all diagnostic logging to
// stderr so enabling debug output never corrupts that channel.
log.Default = log.NewStreamLogger(os.Stderr, os.Stderr, logrus.InfoLevel)

if lvl, err := logrus.ParseLevel(os.Getenv("DEVPOD_LOG_LEVEL")); err == nil {
    log.Default.SetLevel(lvl)
}
if os.Getenv("DEVPOD_DEBUG") == "true" {
    log.Default.SetLevel(logrus.DebugLevel)
}
```

Debug logging works as in #254 and is surfaced by devpod at info level from stderr. Routing logs off stdout also hardens the status/describe/command paths against any stray `Infof`.

## Verification

Provider `status` with `DEVPOD_DEBUG=true`, streams separated:

| | stdout | stderr |
|---|---|---|
| #254 (reverted) | debug logs + status → **ParseStatus fails** | — |
| this PR | **0 bytes / just the status word** | debug lines |

`go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)